### PR TITLE
Handle API responses that do not include a count field

### DIFF
--- a/client-api-ssc/src/main/lombok/com/fortify/client/ssc/api/query/SSCEntityQuery.java
+++ b/client-api-ssc/src/main/lombok/com/fortify/client/ssc/api/query/SSCEntityQuery.java
@@ -55,7 +55,11 @@ public class SSCEntityQuery extends AbstractRestConnectionQuery<JSONMap> {
 	
 	@Override
 	protected void updatePagingDataFromResponse(PagingData pagingData, JSONMap data) {
-		pagingData.setTotalAvailable( data.get("count", Integer.class) );
+		if (data.containsKey("count")) {
+			pagingData.setTotalAvailable( data.get("count", Integer.class) );
+		} else {
+			pagingData.setTotalAvailable(1);
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
Update SSCEntityQuery.java to handle API responses that do not include a count field. Responses to some Fortify SSC API calls, like queryIssueDetailsById in the SSCIssueAPI, return a single item by design and do not include a "count" field. This is causing a NullPointerException for those calls