### PR TITLE
Update to log4j 2.17.0

### DIFF
--- a/fortify-client-api-bom/build.gradle
+++ b/fortify-client-api-bom/build.gradle
@@ -11,7 +11,7 @@ javaPlatform {
 dependencies {
 	api platform('com.fasterxml.jackson:jackson-bom:2.13.0')
 	api platform('org.glassfish.jersey:jersey-bom:2.35')
-	api platform('org.apache.logging.log4j:log4j-bom:2.16.0')
+	api platform('org.apache.logging.log4j:log4j-bom:2.17.0')
 	api platform('org.springframework:spring-framework-bom:5.3.13')
 		
 	constraints {


### PR DESCRIPTION
See https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

Motivation:

log4j 2.16 was recently discovered to be vulnerable to an infinite recursion DOS. Version 2.17 fixes LOG4J2-3230.

Modification:

Change the version from 2.16 to 2.17 for log4j.

Result:

This PR updates log4j to 2.17, which includes a patch for the issue.