### PR TITLE
ci: Migrate to Release-Please v5 and Update Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps: 
       - name: Check-out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
     
       - name: Prepare GitHub release
         id: create_prod_release
@@ -21,7 +21,8 @@ jobs:
         with:
           command: github-release
           release-type: simple
-          package-name: ${{ github.event.repository.name }}
+          skip-github-release: true
+          target-branch: ${{ github.ref_name }}
           
       - name: Define build properties
         run: |
@@ -45,5 +46,4 @@ jobs:
         with:
           command: release-pr
           release-type: simple
-          package-name: ${{ github.event.repository.name }}
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"api","section":"API changes","hidden":false}]'
+          target-branch: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           command: github-release
           release-type: simple
-          skip-github-release: true
           target-branch: ${{ github.ref_name }}
           
       - name: Define build properties

--- a/.github/workflows/fod_scan.yml
+++ b/.github/workflows/fod_scan.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check Out Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       
       - name: Setup Java
         uses: actions/setup-java@v1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,7 @@
+{
+  "changelog-sections": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix",  "section": "Bug Fixes", "hidden": false },
+    { "type": "api",  "section": "API changes", "hidden": false }
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,0 @@
-{
-  "changelog-sections": [
-    { "type": "feat", "section": "Features", "hidden": false },
-    { "type": "fix",  "section": "Bug Fixes", "hidden": false },
-    { "type": "api",  "section": "API changes", "hidden": false }
-  ]
-}


### PR DESCRIPTION
Upgrade actions/checkout@v2 → v6
Remove deprecated package-name parameter from Release-Please steps